### PR TITLE
Fix : box-shadow 컬러값 고정

### DIFF
--- a/front/src/components/Chip/Chip.module.scss
+++ b/front/src/components/Chip/Chip.module.scss
@@ -11,7 +11,7 @@
   border-radius: 15px;
   font-weight: 600;
   font-size: calc(16 * 100vw / 1920);
-  box-shadow: 0 2px 2px 0;
+  box-shadow: 0 2px 2px 0 black;
   &.small {
     min-width: 32px;
     height: 16px;


### PR DESCRIPTION
1. box-shadow 컬러값 고정
- color 값에 따라 box-shadow의 current-color의 영향을 받으므로 컬러값을 black으로 고정